### PR TITLE
Updated eti-cmdline README

### DIFF
--- a/eti-cmdline/README.md
+++ b/eti-cmdline/README.md
@@ -1,122 +1,125 @@
 
-#eti-cmdline
+# eti-cmdline
 
-eti-cmdline is an experimental program - Linux - for creating a stream of
-ETI frames from a selected DAB input channel. The program is fully command
-line driven.
+eti-cmdline is an experimental program for creating a stream of ETI frames 
+from a selected DAB input channel. The program is fully command line driven.
 
-------------------------------------------------------------------
-Table of Contents
-------------------------------------------------------------------
+## Table of Contents
 
-* [Introduction](#introduction)
-* [Supported Devices](#supported devices)
-* Installation
-  * [Linux](#linux)
-        - [Configuring using CMake](#configuring-using-cmake)
-* Command line parameters
- * [Copyright](#copyright)
+* [Supported Devices](#supported-input-devices)
+* [Installation](#installation)
+* [Configuring](#configuring)
+* [Command line parameters](#command-line-parameters)
+* [Copyright](#copyright)
 
----------------------------------------------------------------------
-Supported input devices
----------------------------------------------------------------------
+## Supported input devices
 
 The supported input devices are:
 
-1. Dabsticks that are supported by the osmocom driver software
-
+1. Dabsticks (rtlsdr) that are supported by the osmocom driver software
 2. SDRplay devices (RSP1 and RSP2)
-
 3. AIRSpy devices
+4. prerecorded RAW input files (in format u8, \*.raw)
+5. prerecorded wave files (in format s16le, \*.sdr)
 
-4. prerecorded RAW input files
+## Installation
 
----------------------------------------------------------------------
-Installation
----------------------------------------------------------------------
+For compiling and installing the software `cmake` needs to be installed. 
 
-For compiling and installing the software one needs cmake to be
-installed. Libraries that are required - apart from the libraries
-needed to support the device -
+Required libraries - apart from those needed to support the device - are:
 
 * fftw3
 * libsndfile
-*libsamplerate
------------------------------------------------------------------------
-Configuring
------------------------------------------------------------------------
+* libsamplerate
+
+## Configuring
 
 The "normal" way for configuring and installing is 
-   mkdir build
-   cd build
-   cmake .. -DXXX=ON  [-DDUMPING=ON]
-   make
 
-where XXX refers to the input device being supported, one of
- (RTLSDR, SDRPLAY, AIRSPY, RAWFILES, WAVFILES)
+   	mkdir build
+  	cd build
+   	cmake .. -DXXX=ON  [-DDUMPING=ON]
+   	make
 
-If -DDUMPING=ON is added, the possibility for dumping the input to
-a ".sdr" file (note that an sdr file is a ".wav" file, with a samplerate
-of 2048000 and short int values).
+where XXX refers to the input device being supported, one of 
+(RTLSDR, SDRPLAY, AIRSPY, RAWFILES, WAVFILES)
 
-The resulting program is named eti-cmdline-XXX, for XXX read the devicename
-   (sudo) make install
+If `-DDUMPING=ON` is added, the possibility for dumping the input to a ".sdr" 
+file (note that an sdr file is a ".wav" file, with a samplerate of 2048000 
+and short int values).
 
-will install the created executable in "/usr/local/bin" unless specified
-differently (note that it requires root permissions)
+The resulting program is named `eti-cmdline-XXX`, for XXX see above.
 
-------------------------------------------------------------------------
-Command line parameters
-------------------------------------------------------------------------
-Once the executable is created, it needs to be told what channel you
-want to be read in and converted.
+The command `(sudo) make install` will install the created executable in 
+`/usr/local/bin` unless specified differently (note that it requires root permissions)
+
+
+## Command line parameters
+
+Once the executable is created, it needs to be told what channel you want to be read in and converted.
 
 General parameters are
 
-1. -D number, where number indicates the number of seconds used to collect
-   information on the ensemble. The default value is 10. In 9 out of 10 cases, 
-   if there is not an ensemble detected within 10 seconds, it will never 
-   be detected.
+1. `-D number`, where number indicates the number of seconds used to collect information 
+   on the ensemble. The default value is 10. In 9 out of 10 cases, if there is not an 
+   ensemble detected within 10 seconds, it will never be detected.
+   
    Note that as soon as the software detects a DAB like signal, a message
-   is presented (which can arrive as fast as in 1 or 2 seconds).
+   is printed (which can arrive as fast as in 1 or 2 seconds).
 
-2. -O filename, for specifying the file onto which the ETI frames are written,
+2. `-O filename`, for specifying the file onto which the ETI frames are written,
    "-O -" indicates that the output is to be written to stdout. Note that
    not specifying the "-O" option also causes the output to be written
    to stdout.
 
 For use with one of the physical devices, one may set the following parameters
 
-3. -B ("L_BAND"| "BAND III") for selecting the band. Default BAND III is chosen.
+3. `-B ("L_BAND"| "BAND III")` for selecting the band. Default BAND III is chosen.
 
-4. -C channel,  for selecting the channel to be set, e.g. 11C, default 11C
+4. `-C channel`,  for selecting the channel to be set, e.g. 11C, default 11C
    is chosen
 
-5. -G number, for setting the gain with the device, a number between 0 .. 100,
+5. `-G number`, for setting the gain with the device, a number between 0 .. 100,
    where 100 is the highest gain.
 
-6. -Q, for setting the autogain with the device (assuming the device supports
+6. `-Q`, for setting the autogain with the device (assuming the device supports
    autogain setting)
 
-7. -R filename, for dumping the input to a file as mentioned above. This
+7. `-R filename`, for dumping the input to a file as mentioned above. This
    option only makes sense when dmping is configures.
 
 For use with file input 
 
-8. -F filename, the full pathname for the input file
+8. `-F filename`, the full pathname for the input file
 
-9. -E, is selected the file will be reread after reaching eof.
+9. `-E`, is selected the file will be reread after reaching eof.
 
 For use with rtl_tcp
 
-10. -H hostname, the hostname of the server to connect to, default 127.0.0.1
+10. `-H hostname`, the hostname of the server to connect to, default 127.0.0.1
 
-11. -I port, the port to listen to, default 1234
+11. `-I port`, the port to listen to, default 1234
 
-------------------------------------------------------------------------
-------------------------------------------------------------------------
 
-	Copyright (C)  2016, 2017
+### Writing to eti files
+
+Example:
+
+	eti-cmdline-xxx -C 11C -G 80 > "11C_$(date +%F_%H%M).eti"
+	
+will write an ETI file (with date and time in the filename) to the current directory.
+
+### Piping to dablin
+
+You can use dablin or dablin_gtk from https://github.com/Opendigitalradio/dablin as a frontend by running
+     
+	eti-cmdline-xxx -C 11C -G 80 | dablin_gtk -L
+     
+where xxx refers to the input device being supported, one of (`rtlsdr`, `sdrplay`, `airspy`, `rawfiles`, `wavfiles`).
+
+## Copyright
+
+	Copyright (C)  2016, 2017, 2018
 	Jan van Katwijk (J.vanKatwijk@gmail.com)
 	Lazy Chair Programming
 


### PR DESCRIPTION
TOC rewritten
added sdr as 5th input device
reformatting
updated year
wrong headline 1 (missing space after sharp)
added examples