### PR TITLE
RTL_TCP: Promote to handler

### DIFF
--- a/eti-cmdline/CMakeLists.txt
+++ b/eti-cmdline/CMakeLists.txt
@@ -283,17 +283,17 @@ endif ()
 
 	if (RTL_TCP)
 	   include_directories (
-	      ./devices/rtl_tcp
+	      ./devices/rtl_tcp-handler
 	   )
 
 	   set ($(objectName)_HDRS
 	        ${${objectName}_HDRS}
-	        ./devices/rtl_tcp/rtl_tcp-client.h
+	        ./devices/rtl_tcp-handler/rtl_tcp-handler.h
 	   )
 
 	   set (${objectName}_SRCS
 	        ${${objectName}_SRCS}
-	        ./devices/rtl_tcp/rtl_tcp-client.cpp
+	        ./devices/rtl_tcp-handler/rtl_tcp-handler.cpp
 	   )
 
 	   add_definitions (-DHAVE_RTL_TCP)

--- a/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.cpp
+++ b/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.cpp
@@ -23,7 +23,7 @@
  *    A simple client for rtl_tcp
  */
 
-#include	"rtl_tcp-client.h"
+#include	"rtl_tcp-handler.h"
 //
 	rtl_tcp_client::rtl_tcp_client	(std::string	hostname,
 	                                 int32_t	port,

--- a/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.cpp
+++ b/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.cpp
@@ -25,7 +25,7 @@
 
 #include	"rtl_tcp-handler.h"
 //
-	rtl_tcp_client::rtl_tcp_client	(std::string	hostname,
+	rtl_tcpHandler::rtl_tcpHandler	(std::string	hostname,
 	                                 int32_t	port,
 	                                 int32_t	frequency,
 	                                 int16_t	gain,
@@ -92,16 +92,16 @@
 //
 //	and start the listening thread
 	running. store (false);
-        threadHandle    = std::thread (&rtl_tcp_client::run, this);
+        threadHandle    = std::thread (&rtl_tcpHandler::run, this);
 }
 
-	rtl_tcp_client::~rtl_tcp_client (void) {
+	rtl_tcpHandler::~rtl_tcpHandler (void) {
 	stopReader ();
 
 	close (theSocket);
 }
 
-void	rtl_tcp_client:: run (void) {
+void	rtl_tcpHandler:: run (void) {
 
 	running. store (true);
 	while (running. load ()) {
@@ -121,7 +121,7 @@ void	rtl_tcp_client:: run (void) {
 //	The brave old getSamples. For the dab stick, we get
 //	size: still in I/Q pairs, but we have to convert the data from
 //	uint8_t to std::complex<float>
-int32_t	rtl_tcp_client::getSamples (std::complex<float> *V, int32_t size) { 
+int32_t	rtl_tcpHandler::getSamples (std::complex<float> *V, int32_t size) { 
 int32_t	amount, i;
 uint8_t	*tempBuffer = (uint8_t *)alloca (2 * size * sizeof (uint8_t));
 //
@@ -133,17 +133,17 @@ uint8_t	*tempBuffer = (uint8_t *)alloca (2 * size * sizeof (uint8_t));
 	return amount / 2;
 }
 
-int32_t	rtl_tcp_client::Samples	(void) {
+int32_t	rtl_tcpHandler::Samples	(void) {
 	return  theBuffer	-> GetRingBufferReadAvailable () / 2;
 }
 //
 
 //	bitDepth is is used to set the scale for the spectrum
-int16_t	rtl_tcp_client::bitDepth	(void) {
+int16_t	rtl_tcpHandler::bitDepth	(void) {
 	return 8;
 }
 
-void	rtl_tcp_client::sendCommand (uint8_t cmd, uint32_t param) {
+void	rtl_tcpHandler::sendCommand (uint8_t cmd, uint32_t param) {
 uint8_t theCommand [5];
 
 	theCommand [0]		= cmd;
@@ -154,17 +154,17 @@ uint8_t theCommand [5];
 	write (theSocket, &theCommand, 5);
 }
 
-void	rtl_tcp_client::setVFOFrequency	(int32_t newFrequency) {
+void	rtl_tcpHandler::setVFOFrequency	(int32_t newFrequency) {
 	vfoFrequency = newFrequency;
 	fprintf (stderr, "setting the frequency to %d\n", vfoFrequency);
 	sendCommand (0x01, vfoFrequency);
 }
 
-int32_t	rtl_tcp_client::getVFOFrequency	(void) {
+int32_t	rtl_tcpHandler::getVFOFrequency	(void) {
 	return vfoFrequency;
 }
 
-bool	rtl_tcp_client::restartReader	(void) {
+bool	rtl_tcpHandler::restartReader	(void) {
 
 	if (running)  // The socket is active
 	   return true;
@@ -189,22 +189,22 @@ bool	rtl_tcp_client::restartReader	(void) {
 
 	// Re-Start the listening thread
         running. store (false);
-        threadHandle    = std::thread (&rtl_tcp_client::run, this);
+        threadHandle    = std::thread (&rtl_tcpHandler::run, this);
 
 	return true;
 }
 
-void	rtl_tcp_client::resetBuffer (void) {
+void	rtl_tcpHandler::resetBuffer (void) {
 	theBuffer -> FlushRingBuffer ();
 }
 
-void	rtl_tcp_client::setGain	(int32_t g) {
+void	rtl_tcpHandler::setGain	(int32_t g) {
 	gain	= (int16_t)g;
         fprintf (stderr, "setting the gain to %d\n", gain);
         sendCommand (0x04, 10 * gain);
 }
 
-void	rtl_tcp_client::stopReader (void) {
+void	rtl_tcpHandler::stopReader (void) {
 	if (running) {
 	   running. store (false);
 	   threadHandle. join ();

--- a/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
+++ b/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
@@ -58,15 +58,15 @@ public:
 		                        int16_t		ppm);
 
 			~rtl_tcpHandler	(void);
-	void		setVFOFrequency		(int32_t nf);	// new
-	int32_t		getVFOFrequency		(void);		// new
-	bool		restartReader		(void);		// new
+	void		setVFOFrequency		(int32_t nf);
+	int32_t		getVFOFrequency		(void);
+	bool		restartReader		(void);
 	void		stopReader		(void);
 	int32_t		getSamples		(std::complex<float> *V, int32_t size);
 	int32_t		Samples			(void);
-	void		resetBuffer		(void);		// new
+	void		resetBuffer		(void);
 	int16_t		bitDepth		(void);
-	void		setGain			(int32_t);	// new
+	void		setGain			(int32_t);
 private:
 virtual	void		run		(void);
 	std::string	hostname;

--- a/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
+++ b/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
@@ -58,10 +58,15 @@ public:
 		                        int16_t		ppm);
 
 			~rtl_tcp_client	(void);
-	void		stopReader	(void);
-	int32_t		getSamples	(std::complex<float> *V, int32_t size);
-	int32_t		Samples		(void);
-	int16_t		bitDepth	(void);
+	void		setVFOFrequency		(int32_t nf);	// new
+	int32_t		getVFOFrequency		(void);		// new
+	bool		restartReader		(void);		// new
+	void		stopReader		(void);
+	int32_t		getSamples		(std::complex<float> *V, int32_t size);
+	int32_t		Samples			(void);
+	void		resetBuffer		(void);		// new
+	int16_t		bitDepth		(void);
+	void		setGain			(int32_t);	// new
 private:
 virtual	void		run		(void);
 	std::string	hostname;

--- a/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
+++ b/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
@@ -48,16 +48,16 @@ struct command {
 	unsigned int param;
 }__attribute__((packed));
 
-class	rtl_tcp_client: public deviceHandler {
+class	rtl_tcpHandler: public deviceHandler {
 public:
-			rtl_tcp_client (std::string	hostname,
+			rtl_tcpHandler (std::string	hostname,
 	                                int32_t		port,
 	                                int32_t		frequency,
 	                                int16_t		gain,
 	                                bool		autogain,
 		                        int16_t		ppm);
 
-			~rtl_tcp_client	(void);
+			~rtl_tcpHandler	(void);
 	void		setVFOFrequency		(int32_t nf);	// new
 	int32_t		getVFOFrequency		(void);		// new
 	bool		restartReader		(void);		// new

--- a/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
+++ b/eti-cmdline/devices/rtl_tcp-handler/rtl_tcp-handler.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef	__RTL_TCP_CLIENT
-#define	__RTL_TCP_CLIENT
+#ifndef	__RTL_TCP_HANDLER__
+#define	__RTL_TCP_HANDLER__
 #include	<iostream>
 #include	<sstream>
 #include	<errno.h>

--- a/eti-cmdline/main.cpp
+++ b/eti-cmdline/main.cpp
@@ -51,7 +51,7 @@ using std::endl;
 #elif	HAVE_WAVFILES
 #include	"wavfile-handler.h"
 #elif	HAVE_RTL_TCP
-#include	"rtl_tcp-client.h"
+#include	"rtl_tcp-handler.h"
 #endif
 //
 //	Be aware that the callbacks may arrive from different threads,

--- a/eti-cmdline/main.cpp
+++ b/eti-cmdline/main.cpp
@@ -330,7 +330,7 @@ int32_t		basePort = 1234;
 	                                      continue_on_eof,
 	                                      inputStopped);
 #elif	HAVE_RTL_TCP
-	   inputDevice = new rtl_tcp_client (hostname,
+	   inputDevice = new rtl_tcpHandler (hostname,
 	                                     basePort,
 	                                     tunedFrequency,
 	                                     deviceGain,


### PR DESCRIPTION
This patch includes some missing functions present in the interface Handler. After incorporate these functions the TCP input device has the same functionality as the native RTL-SDR. 