### PR TITLE
Ppm correction for rtlsdr

### DIFF
--- a/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.cpp
+++ b/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.cpp
@@ -134,7 +134,7 @@ int16_t	deviceIndex;
 	gains		= new int [gainsCount];
 	gainsCount	= rtlsdr_get_tuner_gains (device, gains);
         rtlsdr_set_tuner_gain_mode (device, autogain);
-	rtlsdr_set_tuner_gain (device,gains [theGain * gainsCount / 100]);
+	rtlsdr_set_tuner_gain (device,gains [theGain * (gainsCount - 1) / 100]);
         
 	r		= rtlsdr_set_freq_correction (device, ppmCorrection);
 

--- a/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.cpp
+++ b/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.cpp
@@ -139,7 +139,7 @@ int16_t	deviceIndex;
 	if (ppmCorrection > 0) {
 	   r		= rtlsdr_set_freq_correction (device, ppmCorrection);
 
-           if (r == 0) {
+	   if (r == 0) {
 	      r = rtlsdr_get_freq_correction(device);
 	      fprintf (stderr, "Frequency correction set to: %d ppm\n", r);
 	   }
@@ -209,7 +209,7 @@ int32_t	r;
 	this -> rtlsdr_set_center_freq (device, frequency + vfoOffset);
 	workerHandle = std::thread (controlThread, this);
 	rtlsdr_set_tuner_gain_mode (device, autogain);
-	rtlsdr_set_tuner_gain (device, gains [theGain * gainsCount / 100]);
+	rtlsdr_set_tuner_gain (device, gains [theGain * (gainsCount - 1) / 100]);
 	running	= true;
 	return true;
 }
@@ -227,12 +227,12 @@ void	rtlsdrHandler::stopReader		(void) {
 //	first find the table value
 void	rtlsdrHandler::setGain	(int32_t g) {
 	theGain	= g;
-	rtlsdr_set_tuner_gain (device, gains [theGain * gainsCount / 100]);
+	rtlsdr_set_tuner_gain (device, gains [theGain * (gainsCount - 1) / 100]);
 }
 	
 void	rtlsdrHandler::setAgc		(bool b) {
 	rtlsdr_set_tuner_gain_mode (device, b);
-	rtlsdr_set_tuner_gain (device, gains [theGain * gainsCount / 100]);
+	rtlsdr_set_tuner_gain (device, gains [theGain * (gainsCount - 1) / 100]);
 }
 
 //

--- a/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.cpp
+++ b/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.cpp
@@ -135,15 +135,17 @@ int16_t	deviceIndex;
 	gainsCount	= rtlsdr_get_tuner_gains (device, gains);
         rtlsdr_set_tuner_gain_mode (device, autogain);
 	rtlsdr_set_tuner_gain (device,gains [theGain * (gainsCount - 1) / 100]);
-        
-	r		= rtlsdr_set_freq_correction (device, ppmCorrection);
 
-        if (r == 0) {
-	   r = rtlsdr_get_freq_correction(device);
-	   fprintf (stderr, "Frequency correction set to: %d ppm\n", r);
-	}
-	else {
-	   fprintf (stderr, "Setting frequency correction failed\n");
+	if (ppmCorrection > 0) {
+	   r		= rtlsdr_set_freq_correction (device, ppmCorrection);
+
+           if (r == 0) {
+	      r = rtlsdr_get_freq_correction(device);
+	      fprintf (stderr, "Frequency correction set to: %d ppm\n", r);
+	   }
+	   else {
+	      fprintf (stderr, "Setting frequency correction failed\n");
+	   }
 	}
 
 	_I_Buffer	= new RingBuffer<uint8_t>(1024 * 1024);

--- a/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.h
+++ b/eti-cmdline/devices/rtlsdr-handler/rtlsdr-handler.h
@@ -52,6 +52,7 @@ typedef int (*  pfnrtlsdr_cancel_async) (rtlsdr_dev_t *);
 typedef int (*  pfnrtlsdr_set_direct_sampling) (rtlsdr_dev_t *, int);
 typedef uint32_t (*  pfnrtlsdr_get_device_count) (void);
 typedef	int (* pfnrtlsdr_set_freq_correction)(rtlsdr_dev_t *, int);
+typedef	int (* pfnrtlsdr_get_freq_correction)(rtlsdr_dev_t *);
 typedef	char *(* pfnrtlsdr_get_device_name)(int);
 }
 //	This class is a simple wrapper around the
@@ -59,7 +60,7 @@ typedef	char *(* pfnrtlsdr_get_device_name)(int);
 //	It does not do any processing
 class	rtlsdrHandler: public deviceHandler {
 public:
-			rtlsdrHandler	(int32_t, int16_t, bool);
+			rtlsdrHandler	(int32_t, int16_t, int16_t, bool);
 			~rtlsdrHandler	(void);
 	void		setVFOFrequency	(int32_t);
 	int32_t		getVFOFrequency	(void);
@@ -82,6 +83,7 @@ public:
 	int32_t		sampleCounter;
 private:
 	int32_t		lastFrequency;
+	int16_t		ppmCorrection;
 	int16_t		theGain;
 	bool		autogain;
 	
@@ -113,6 +115,7 @@ private:
 	pfnrtlsdr_set_direct_sampling	rtlsdr_set_direct_sampling;
 	pfnrtlsdr_get_device_count rtlsdr_get_device_count;
 	pfnrtlsdr_set_freq_correction rtlsdr_set_freq_correction;
+	pfnrtlsdr_get_freq_correction rtlsdr_get_freq_correction;
 	pfnrtlsdr_get_device_name rtlsdr_get_device_name;
 };
 #endif

--- a/eti-cmdline/main.cpp
+++ b/eti-cmdline/main.cpp
@@ -273,7 +273,16 @@ int32_t		basePort = 1234;
 	         break;
 
 	      case 'G':
-	         deviceGain	= atoi (optarg);
+	         {
+	            int deviceGainArg = atoi (optarg);
+
+	            if ((deviceGainArg >= 0) && (deviceGainArg <= 100)) {
+	               deviceGain	= deviceGainArg;
+	            }
+	            else {
+	               fprintf(stderr, "Invalid gain value, using default: %d\n", deviceGain);
+	            }
+	         }
 	         break;
 
 	      case 'Q':
@@ -382,7 +391,7 @@ int32_t		basePort = 1234;
 //	give time to collect data on the ensemble and the programs
 //
 	while (--freqSyncTime > 0) {
-	   cerr << "still at most " << freqSyncTime <<  "seconds to wait\r";
+	   cerr << "\33[2Kstill at most " << freqSyncTime <<  " seconds to wait\r";
 	   sleep (1);
 	   if (ensembleRecognized. load ()) {
 	      theWorker. set_syncReached ();

--- a/eti-cmdline/main.cpp
+++ b/eti-cmdline/main.cpp
@@ -313,7 +313,7 @@ int32_t		basePort = 1234;
 
 	try {
 #ifdef	HAVE_RTLSDR
-	   inputDevice	= new rtlsdrHandler (tunedFrequency,
+	   inputDevice	= new rtlsdrHandler (tunedFrequency, ppmCorrection,
 	                                        deviceGain, autoGain);
 #elif	HAVE_SDRPLAY
 	   inputDevice	= new sdrplayHandler (tunedFrequency, ppmCorrection,


### PR DESCRIPTION
I experienced that eti-cmdline did not sync reliably with my rtlsdr dongle on a certain channel. I could fix this issue by introducing the ppm correction for this device which has not been implemented yet.

BTW: I have also enabled dablin to pass-through command line options to eti-cmdline (like '-P xxx'), see https://github.com/Opendigitalradio/dablin/pull/40.