### PR TITLE
allow channel in lowercase in syntax

### DIFF
--- a/eti-cmdline/main.cpp
+++ b/eti-cmdline/main.cpp
@@ -330,6 +330,7 @@ struct sigaction sigact;
 
 	      case 'C':
 	         theChannel	= std::string (optarg);
+			   for (auto & c: theChannel) c = toupper(c);
 	         break;
 
 #if defined (HAVE_SDRPLAY)


### PR DESCRIPTION
This PR allows channel numbers also in lowercase in the syntax.

# Before

The original syntax required uppercase channel numbers like 5A till 13F. A lower case channel number automatically got 5A. 

```
$ eti-cmdline-rtlsdr -Q -C 13f
tunedFrequency =  174928000   # wrong frequency for 13F
```

# After

Now the optarg is internally converted to uppercase in order to allow lower case channel numbers in the syntax:

```
$ eti-cmdline-rtlsdr -Q -C 13f
tunedFrequency =  239200000   # correct frequency for 13F
```

