### PR TITLE
valid channel name check

### DIFF
--- a/eti-cmdline/src/support/band-handler.cpp
+++ b/eti-cmdline/src/support/band-handler.cpp
@@ -31,6 +31,7 @@ struct dabFrequencies {
 
 static
 struct dabFrequencies bandIII_frequencies [] = {
+{"other",    0},
 {"5A",	174928},
 {"5B",	176640},
 {"5C",	178352},


### PR DESCRIPTION
# Before

If the optarg for `-C` is any other string than declared (like "text" in the sample below), the program assigns the value for 5A (which is the first entry in the list to be found in `band-handler.cpp`) instead of producing an error or set it to 0.

```
$ eti-cmdline-rtlsdr -Q -C text
tunedFrequency =  174928000
```

# After

Now it's clear for the user, that his syntax was wrong (as the frequency got 0)

```
$ ./eti-cmdline-rtlsdr -Q -C text
tunedFrequency =  0
```

or illegal channel number 

```
$ ./eti-cmdline-rtlsdr -Q -C 5E
tunedFrequency =  0
```