### PR TITLE
Increase 'sleep' stability

### DIFF
--- a/eti-cmdline/includes/dab-constants.h
+++ b/eti-cmdline/includes/dab-constants.h
@@ -42,6 +42,10 @@ static inline void usleep(int u) { Sleep(u / 1000); }
 #include	<unistd.h>
 #include	"alloca.h"
 #include	"dlfcn.h"
+#include	<thread>
+#include	<chrono>
+static inline void sleep(int s) { std::this_thread::sleep_for(std::chrono::seconds(s)); }
+static inline void usleep(int u) { std::this_thread::sleep_for(std::chrono::microseconds(u)); }
 typedef	void	*HINSTANCE;
 #endif
 


### PR DESCRIPTION
Standard 'sleep' function can be interrupted by a signal, which leads to instability of recordTime counter (and possible other time-dependent tasks too). Observed anomaly here on RPI: https://asciinema.org/a/yopUpkTPTG2OHxM1R1jjaItSY

This change switches globally 'sleep' from `<unistd.h>` to more stable 'sleep_for' from `<thread>`.