### PR TITLE
fixed building eti-cmdline-xml

### DIFF
--- a/eti-cmdline/devices/xml-filereader/xml-filereader.cpp
+++ b/eti-cmdline/devices/xml-filereader/xml-filereader.cpp
@@ -39,7 +39,7 @@
 	xml_fileReader::xml_fileReader (std::string fileName,
 	                                bool	continue_on_eof,
 	                                inputstopped_t inputStopped):
-	                                  _I_Buffer (INPUT_FRAMEBUFFERS) {
+	                                  _I_Buffer (INPUT_FRAMEBUFFERSIZE) {
 	this -> fileName	= fileName;
 	theFile	= fopen (fileName.c_str (), "rb");
 	if (theFile == nullptr) {


### PR DESCRIPTION
# before 

```
$ make
Consolidate compiler generated dependencies of target eti-cmdline-xml
[  3%] Building CXX object CMakeFiles/eti-cmdline-xml.dir/devices/xml-filereader/xml-filereader.cpp.o
/home/andreas/apps/eti-stuff/eti-cmdline/devices/xml-filereader/xml-filereader.cpp: In constructor ‘xml_fileReader::xml_fileReader(std::string, bool, inputstopped_t)’:
/home/andreas/apps/eti-stuff/eti-cmdline/devices/xml-filereader/xml-filereader.cpp:40:54: error: ‘INPUT_FRAMEBUFFERS’ was not declared in this scope; did you mean ‘INPUT_FRAMEBUFFERSIZE’?
   40 |                                           _I_Buffer (INPUT_FRAMEBUFFERS) {
      |                                                      ^~~~~~~~~~~~~~~~~~
      |                                                      INPUT_FRAMEBUFFERSIZE
make[2]: *** [CMakeFiles/eti-cmdline-xml.dir/build.make:398: CMakeFiles/eti-cmdline-xml.dir/devices/xml-filereader/xml-filereader.cpp.o] Fehler 1
make[1]: *** [CMakeFiles/Makefile2:84: CMakeFiles/eti-cmdline-xml.dir/all] Fehler 2
make: *** [Makefile:136: all] Fehler 2
```

# after 

```
[100%] Built target eti-cmdline-xml
```