### PR TITLE
help text (-h) depending on xxx

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ eti-cmdline now supports a whole range of device (the device is for cmake comman
  - RTL_TCP: for rtl_tcp input (and multiple DABsticks support),
  - RAWFILES: for 8bit unsigned raw files
  - WAVFILES: for 16bit wave files
- - XML_FILES: for uff and xml files, created by Qt-DAB or Qirx
+ - XMLFILES: for uff and xml files, created by Qt-DAB or Qirx
 
 eti-cmdline now can be compiled for Windows using
 msvc (thanks to Andreas Gorsak). The directory contains a folder
@@ -54,7 +54,7 @@ You can use dablin or dablin_gtk from https://github.com/Opendigitalradio/dablin
       
       eti-cmdline-xxx -C 11C -G 80 | dablin_gtk
       
-where xxx refers to the input device being supported, one of (`rtlsdr`, `sdrplay`, `sdrplay-v3`, `pluto`, `airspy`, `hackrf`, `limesdr`, `rawfiles`, `wavfiles`, `xml_files`, `rtl_tcp`).
+where xxx refers to the input device being supported, one of (`rtlsdr`, `sdrplay`, `sdrplay-v3`, `pluto`, `airspy`, `hackrf`, `limesdr`, `rawfiles`, `wavfiles`, `xmlfiles`, `rtl_tcp`).
       
 # Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ When building for Linux, you can use CMake to have a makefile generated.
 Select the input device of choice in the CMake command, for example
 
       cmake -DRTLSDR=ON  # for DABSticks
-or    cmake -DRAWFILES=ON # for u8 raw files
+
+or    
+
+      cmake -DRAWFILES=ON # for u8 raw files
       make
       sudo make install
      

--- a/eti-cmdline/CMakeLists.txt
+++ b/eti-cmdline/CMakeLists.txt
@@ -100,7 +100,7 @@ if(WAVFILES)
 endif ()
 
 if(XMLFILES)
-	set (objectName eti-cmdline-xml)
+	set (objectName eti-cmdline-xmlfiles)
 	list (APPEND INPUTS "XMLFILES")
 endif ()
 
@@ -557,7 +557,7 @@ endif()
 	        ./devices/xml-filereader/xml-descriptor.cpp
 	   )
 
-	   add_definitions (-DHAVE_XML_FILES)
+	   add_definitions (-DHAVE_XMLFILES)
 	endif (XMLFILES)
 
 	include_directories (

--- a/eti-cmdline/README.md
+++ b/eti-cmdline/README.md
@@ -1,54 +1,54 @@
 
--------------------------------------------------------------------
+
 # eti-cmdline
---------------------------------------------------------------------
 
 eti-cmdline is an experimental program for creating a stream of ETI frames 
 from a selected DAB input channel. The program is fully command line driven.
 
---------------------------------------------------------------------
+
 ## Table of Contents
---------------------------------------------------------------------
 
 * [Supported Devices](#supported-input-devices)
 * [Installation under Windows](#installation-under-windows)
-* [Installation Linux](#installation-Linux)
-* [Configuring CMake](#configuring-CMake)
+* [Installation Linux](#installation-under-linux)
+* [Configuring CMake](#configuring-cmake)
 * [Command line parameters](#command-line-parameters)
+* [Writing to eti files](#writing-to-eti-files)
+* [Piping to DABlin](#piping-to-dablin)
 * [Copyright](#copyright)
 
-----------------------------------------------------------------------
+
 ## Supported input devices
-----------------------------------------------------------------------
 
-The supported input devices are:
+eti-cmdline now supports a whole range of device (the device is for cmake command, see below):
 
-1. Dabsticks (rtlsdr) that are supported by the osmocom driver software
-2. SDRplay devices (separate entries for use with the 2.13 or the 3.0x library)
-3. AIRSpy devices
-4. HACKrf devices
-5. Lime  devices
-6. Pluto devices
-7. prerecorded RAW input files (in format u8, \*.raw)
-8. prerecorded wave files (in format s16le, \*.sdr)
-9. prerecorded files in xml format (experimental)
+    RTLSDR: for DABStickes based on Realtek 2832 chipset,
+    AIRSPY: for Airspy R2 and Airspy mini devices (not for Airspy HF+),
+    SDRPLAY: for SDRPlay RSP devices using the 2.13 SDRplay library,
+    SDRPLAY_V3: for SDRPlay RSP devices using the 3.06/7 SDRplay library,
+    PLUTO: for Adalm Pluto devices,
+    HACKRF: for HackRF devices,
+    LIMESDR: for LimeSDR devices
+    RTL_TCP: for rtl_tcp input (and multiple DABsticks support),
+    RAWFILES: for 8bit unsigned raw files
+    WAVFILES: for 16bit wave files
+    XMLFILES: for uff and xml files, created by Qt-DAB or Qirx
+
 
 Of course one needs to have the library for device support installed.
 Note that in the current version, no link to fftw libraries is needed,
 the current version uses Kiss_fft.
 
-------------------------------------------------------------------------
+
 ## Installation under Windows
-------------------------------------------------------------------------
 
 The directory contains a subdirectory "build-for-msvc" with the required
 configuration files for compilation using MSVC. The configuration file
 "eti-cmdline.vcxproj" is configured for the SDRplay device (using the 2.13
 library). Change to your needs.
 
-------------------------------------------------------------------------
-## Installation Linux
-------------------------------------------------------------------------
+
+## Installation under Linux
 
 For compiling and installing under Linux `cmake` needs to be installed. 
 
@@ -56,9 +56,8 @@ Note that for use of pluto both "libiio" and "libad9361" need to be
 installed. Note further that older systems (e.g. Ubuntu 16.04) do not
 have the correct implementations of these packages in their repositories
 
-------------------------------------------------------------------------
+
 ## Configuring CMake
-------------------------------------------------------------------------
 
 The "normal" way for configuring and installing is 
 
@@ -75,28 +74,27 @@ the SDRplay devices RSP 1, RSP II, RSP 1A, and RSP Duo are supported
 by both the 2.13 library and the 3.0x library.
 The RSP-Dx is only supported by the 3.0x library
 
-Use -DSDRPLAY=ON for installing the support software linking to the 2.13 lib
-Use -DSDRPLAY_V3=ON for installing the 3.0x support
+Use `-DSDRPLAY=ON` for installing the support software linking to the 2.13 lib
+Use `-DSDRPLAY_V3=ON` for installing the 3.0x support
 
 If `-DDUMPING=ON` is added, the possibility for dumping the input to an ".sdr" 
 file (note that an sdr-file is a ".wav" file, with a samplerate of 2048000 
 and short int values).
 
-If `-DX64_DEFINED=ON' is added, SSE instructions will be used in the viterbi decoding.
+If `-DX64_DEFINED=ON` is added, SSE instructions will be used in the viterbi decoding.
 
-If `-DRPI_DEFINED=ON' is added and building takes place on an RPI, an attempt
+If `-DRPI_DEFINED=ON` is added and building takes place on an RPI, an attempt
 is made to use neon insrtructions. Note however that there might
 be problems with the toolchain: different toolchains require different
-flags. See the section in the CMakeLists.txt file
+flags. See the section in the `CMakeLists.txt` file
 
 The resulting program is named `eti-cmdline-XXX`, for XXX see above.
 
 The command `(sudo) make install` will install the created executable in 
 `/usr/local/bin` unless specified differently (note that it requires root permissions)
 
---------------------------------------------------------------------------
+
 ## Command line parameters
---------------------------------------------------------------------------
 
 Once the executable is created, it needs to be told what channel you want to be read in and converted.
 
@@ -130,14 +128,13 @@ For use with one of the physical devices, one may set the following parameters
 6. `-C channel`,  for selecting the channel to be set, e.g. 11C, default 11C
    is chosen
 
-7. `-S', for silent processing, normally, while processing the program
+7. `-S`, for silent processing, normally, while processing the program
 shows a count on the amount of packages written on stderr.
 
-For device specific settings: run ./eti-cmdline -h
+For device specific settings: run `./eti-cmdline-xxx -h`
 
--------------------------------------------------------------------------
+
 ### Writing to eti files
---------------------------------------------------------------------------
 
 Example:
 
@@ -153,9 +150,8 @@ You can use dablin or dablin_gtk from https://github.com/Opendigitalradio/dablin
      
 where xxx refers to the input device being supported, one of (`rtlsdr`, `sdrplay`, `airspy`, `hackrf`, `limesdr', `rawfiles`, `wavfiles`).
 
------------------------------------------------------------------------------
+
 ## Copyright
------------------------------------------------------------------------------
 
 	Copyright (C)  2016, 2017, 2018, 2019, 2020
 	Jan van Katwijk (J.vanKatwijk@gmail.com)

--- a/eti-cmdline/main.cpp
+++ b/eti-cmdline/main.cpp
@@ -141,7 +141,7 @@ using std::endl;
 #include	"wavfile-handler.h"
 #elif	HAVE_RTL_TCP
 #include	"rtl_tcp-client.h"
-#elif	HAVE_XML_FILES
+#elif	HAVE_XMLFILES
 #include	"xml-filereader.h"	// does not work yet
 #endif
 //
@@ -316,7 +316,7 @@ std::string	fileName;
 bool		repeater	= true;
 bool		continue_on_eof	= false;
 const char	*optionsString	= "ShP:D:d:M:B:O:F:rt:";
-#elif	HAVE_XML_FILES
+#elif	HAVE_XMLFILES
 std::string	fileName;
 bool		repeater	= true;
 bool		continue_on_eof	= false;
@@ -405,7 +405,7 @@ struct sigaction sigact;
 	            theMode = 1; 
 	         break;
 
-#if	defined (HAVE_RAWFILES) || defined (HAVE_WAVFILES) || defined (HAVE_XML_FILES)
+#if	defined (HAVE_RAWFILES) || defined (HAVE_WAVFILES) || defined (HAVE_XMLFILES)
 	      case 'F':
 	         fileName	= std::string (optarg);
 	         break;
@@ -557,7 +557,7 @@ struct sigaction sigact;
 	the_callBacks. theFibQuality	= fibqualityHandler;
 	the_callBacks. theInputStopped	= inputStoppedHandler;
 
-#if defined(HAVE_RAWFILES) || defined(HAVE_WAVFILES) || defined (HAVE_XML_FILES)
+#if defined(HAVE_RAWFILES) || defined(HAVE_WAVFILES) || defined (HAVE_XMLFILES)
 //	check on name ??
 #else
 	tunedFrequency	=  the_bandHandler. Frequency (theBand, theChannel);
@@ -611,7 +611,7 @@ struct sigaction sigact;
 	   inputDevice	= new wavfileHandler (fileName,
 	                                      continue_on_eof,
 	                                      inputStoppedHandler);
-#elif	HAVE_XML_FILES
+#elif	HAVE_XMLFILES
 	   inputDevice	= new xml_fileReader (fileName,
 	                                      continue_on_eof,
 	                                      inputStoppedHandler);
@@ -715,62 +715,97 @@ struct sigaction sigact;
 
 void    printOptions (void) {
         std::cerr << 
-" general eti-cmdline-xxx options are\n"
-"\n"
-"   -P number	number of parallel threads for handling subchannels\n"
-"   -D number   time (in seconds) to look for a DAB ensemble\n"
-"   -M mode     Mode to be used \n"
-"   -B Band     select DAB Band (default: BAND_III, or L_BAND)\n"
-"   -C channel  DAB channel to be used (5A ... 13F resp. LA ... LP)\n"
-"   -O filename write output into a file (instead of stdout)\n"
-"   -R filename (if configured) dump to an *.sdr file\n"
-"   -S          be silent during processing\n"
-"   -t          set record time\n"
-"   -h          show options and quit\n"; 
-
+"\n eti-cmdline-";
 #ifdef	HAVE_WAVFILES
-	std::cerr << 
-"   -F filename, -r repeat after reaching eof\n";
+	std::cerr << "wavfiles";
+#elif	HAVE_XMLFILES
+	std::cerr << "xmlfiles";
 #elif	HAVE_RAWFILES
-	std::cerr << 
-"   -F filename, -r repeat after reaching eof\n";
+	std::cerr << "rawfiles";
+#elif	HAVE_SDRPLAY
+	std::cerr << "sdrplay";
+#elif	HAVE_AIRSPY
+	std::cerr << "airspy";
+#elif	HAVE_HACKRF
+	std::cerr << "hackrf";
+#elif	HAVE_RTLSDR
+	std::cerr << "rtlsdr";
+#elif	HAVE_LIME
+	std::cerr << "limesdr";
+#elif	HAVE_PLUTO
+	std::cerr << "pluto";
+#elif	HAVE_RTL_TCP
+	std::cerr << "rtl_tcp";
+#endif
+	std::cerr <<
+" was compiled from \n"
+" https://github.com/JvanKatwijk/eti-stuff/\n\n"
+" It is an experimental program for creating a\n"
+" stream of ETI frames from a selected DAB input channel.\n\n"
+" The options are\n\n"
+"   -P number   number of parallel threads for handling subchannels\n"
+"   -D number   time (in seconds) to look for a DAB ensemble\n"
+"   -M mode     mode to be used \n"
+"   -O filename write output into a file (instead of stdout)\n";
+
+#if !(defined(HAVE_XMLFILES) || defined(HAVE_WAVFILES) || defined(HAVE_RAWFILES))
+	std::cerr <<
+"   -B Band     select DAB Band (default: BAND_III, or L_BAND)\n"
+"   -C channel  DAB channel to be used (5A ... 13F resp. LA ... LP)\n";
+#endif
+
+#ifdef	HAVE_DUMPFILE
+	std::cerr <<
+"   -R filename dump to an *.sdr file\n";
+#endif
+	std::cerr <<
+"   -S          be silent during processing\n"
+"   -t          set record time\n";
+
+#if defined(HAVE_RAWFILES) || defined(HAVE_WAVFILES) || defined (HAVE_XMLFILES)
+	std::cerr <<
+"   -F filename\n"
+"   -r          repeat after reaching eof\n";
+
 #elif	HAVE_SDRPLAY
 	std::cerr <<
-"   -G number ifgain reduction (20 .. 59), \n"
-"   -L number lna state selection \n"
-"   -Q autogain on \n"
-"   -p number ppm correction \n";
+"   -G number   ifgain reduction (20 .. 59), \n"
+"   -L number   lna state selection \n"
+"   -Q          autogain on \n"
+"   -p number   ppm correction \n";
 #elif	HAVE_AIRSPY
 	std::cerr <<
-"   -G number Gain (combined gain in the range 1 .. 21) \n"
-"   -b bias on\n";
+"   -G number   gain (combined gain in the range 1 .. 21) \n"
+"   -b          bias on\n";
 #elif	HAVE_HACKRF
 	std::cerr <<
-"   -G number lna gain \n"
-"   -g number vga gain \n"
-"   -A ampEnable on\n"
-"   -p number ppm correction\n";
+"   -G number   lna gain \n"
+"   -g number   vga gain \n"
+"   -A          ampEnable on\n"
+"   -p number   ppm correction\n";
 #elif	HAVE_RTLSDR
 	std::cerr <<
-"   -G number gain setting, depending on the version of the stick \n"
-"   -p number ppm setting \n"
-"   -Q autogain on\n";
+"   -G number   gain setting, depending on the version of the stick \n"
+"   -p number   ppm setting \n"
+"   -Q          autogain on\n";
 #elif	HAVE_LIME
 	std::cerr << 
-"   -G number gain setting \n"
-"   -X string antenna setting\n";
+"   -G number   gain setting \n"
+"   -X string   antenna setting\n";
 #elif	HAVE_PLUTO
 	std::cerr <<
-	"-G number gain setting\n"
-	"-Q audiogain of (default off)\n"
-	"-F filter off (default on)\n"
+"   -G number   gain setting\n"
+"   -Q          autogain on (default off)\n"
+"   -F          filter off (default on)\n"
 #elif	HAVE_RTL_TCP
 	std::cerr <<
-"   -G number gain setting \n"
-"   -Q autogain on \n"
-"   -p number ppm correction \n"
-"   -H string hostname \n"
-"   -I number baseport\n";
+"   -G number   gain setting \n"
+"   -Q          autogain on \n"
+"   -p number   ppm correction \n"
+"   -H string   hostname \n"
+"   -I number   baseport\n";
 #endif
+	std::cerr <<
+"\n   -h          show options and quit\n\n";
 }
 


### PR DESCRIPTION
# main changes

## some typos:
- audiogain -> autogain
- typo fixed (of -> on)

## help-text
- xxx replaced by name in helptext, for example

### before

```
$ eti-cmdline-rtlsdr -h
 general eti-cmdline-xxx options are

   -P number	number of parallel threads for handling subchannels
   -D number   time (in seconds) to look for a DAB ensemble
   -M mode     Mode to be used 
   -B Band     select DAB Band (default: BAND_III, or L_BAND)
   -C channel  DAB channel to be used (5A ... 13F resp. LA ... LP)
   -O filename write output into a file (instead of stdout)
   -R filename (if configured) dump to an *.sdr file
   -S          be silent during processing
   -t          set record time
   -h          show options and quit
   -G number gain setting, depending on the version of the stick 
   -p number ppm setting 
   -Q autogain on

```

### after 

```
$ ./eti-cmdline-rtlsdr -h

 eti-cmdline-rtlsdr was compiled from 
 https://github.com/JvanKatwijk/eti-stuff/

 It is an experimental program for creating a
 stream of ETI frames from a selected DAB input channel.

 The options are

   -P number   number of parallel threads for handling subchannels
   -D number   time (in seconds) to look for a DAB ensemble
   -M mode     mode to be used 
   -O filename write output into a file (instead of stdout)
   -B Band     select DAB Band (default: BAND_III, or L_BAND)
   -C channel  DAB channel to be used (5A ... 13F resp. LA ... LP)
   -S          be silent during processing
   -t          set record time
   -G number   gain setting, depending on the version of the stick 
   -p number   ppm setting 
   -Q          autogain on

   -h          show options and quit
```



- adjusted the options according to the xxx 
- placed `-h` to the end
- added homepage on top
- columns fixed
- show "dump" helptext only when compiled
- do not show option for channel in case of prerecorded files
- hint: the xml reader works, indeed

## fixed xml name 
- XMLFILES instead of XML_FILES
- renamed `eti-cmdline-xml` to `eti-cmdline-xmlfiles`

## uses md syntax
- removed useless lines